### PR TITLE
Add Gitignore to Application Generator

### DIFF
--- a/src/prop_application.erl
+++ b/src/prop_application.erl
@@ -43,6 +43,7 @@ generate_release_app(Prop) ->
 generate_standalone_app(Prop) ->
   Name = prop:name(Prop),
   prop:template(Prop, "README.md", [Name, "README.md"]),
+  prop:template(Prop, "gitignore", [Name, ".gitignore"]),
   generate_common_templates(Prop, Name).
 
 release_option() -> {release, $r, "release", boolean, ""}.

--- a/src/prop_application.erl
+++ b/src/prop_application.erl
@@ -4,7 +4,9 @@
 -export([generate/1, name/0, description/0, options/0]).
 
 name() -> application.
+
 description() -> "Generate an application.".
+
 options() -> [release_option(), description_option()].
 
 generate(Prop) ->
@@ -23,25 +25,24 @@ generate_app(undefined, Prop) ->
   InReleaseDir = filelib:is_dir("apps"),
   generate_app(InReleaseDir, Prop).
 
-generate_release_app(Prop) ->
-  Name = prop:name(Prop),
-  Root = case prop:root_directory(Prop) of
-    undefined -> filename:join(["apps", Name]);
-    RootDirectory -> filename:join([RootDirectory, "apps", Name])
-  end,
+generate_common_templates(Prop, Root) ->
   prop:template(Prop, "app.erl", [Root, "src", "{{name}}_app.erl"]),
   prop:template(Prop, "mod.erl", [Root, "src", "{{name}}.erl"]),
   prop:template(Prop, "sup.erl", [Root, "src", "{{name}}_sup.erl"]),
   prop:template(Prop, "app.app", [Root, "ebin", "{{name}}.app"]),
   prop:template(Prop, "rebar.config", [Root, "rebar.config"]).
 
+generate_release_app(Prop) ->
+  Name = prop:name(Prop),
+  Root = case prop:root_directory(Prop) of
+    undefined -> filename:join(["apps", Name]);
+    RootDirectory -> filename:join([RootDirectory, "apps", Name])
+  end,
+  generate_common_templates(Prop, Root).
+
 generate_standalone_app(Prop) ->
   Name = prop:name(Prop),
   prop:template(Prop, "README.md", [Name, "README.md"]),
-  prop:template(Prop, "app.erl", [Name, "src", "{{name}}_app.erl"]),
-  prop:template(Prop, "mod.erl", [Name, "src", "{{name}}.erl"]),
-  prop:template(Prop, "sup.erl", [Name, "src", "{{name}}_sup.erl"]),
-  prop:template(Prop, "app.app", [Name, "ebin", "{{name}}.app"]),
-  prop:template(Prop, "rebar.config", [Name, "rebar.config"]).
+  generate_common_templates(Prop, Name).
 
 release_option() -> {release, $r, "release", boolean, ""}.


### PR DESCRIPTION
Generate a .gitignore if we're creating a stand-alone application.